### PR TITLE
移除 pm2 启动脚本

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,6 @@ jobs:
           cp .env server/.env.production
           cp package.json server/package.json
           cp package-lock.json server/package-lock.json
-          cp ecosystem.config.js server/ecosystem.config.js
           cp readme.md server/readme.md
           cp LICENSE server/LICENSE
 


### PR DESCRIPTION
移除 pm2 启动脚本，该脚本导致 Windows Defener 错误报警，检测到 Trojan:Script/Wacatac.B!ml 木马病毒。